### PR TITLE
Added count_members, list_members functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.flake8
+.pylintrc
 
 # Translations
 *.mo

--- a/bot.py
+++ b/bot.py
@@ -36,19 +36,20 @@ async def hello(ctx):
     await ctx.send("hi")
 
 
+"""
 @bot.command()
-async def count_members(ctx, *, output_string: str):
-    """Reads the message from the chat and returns the number of members
+async def count_members(ctx, *, discord_string: str):
+    Reads the message from the chat and returns the number of members
     that meet the conditions.
 
     Reads the message if the message starts with the "command_prefix"
     (that was set in when initializing commands.Bot object) and the name
     in the title of the method. Returns str in "ctx.send()".
-    """
+
     only_nots_in_str = False
-    if "not " in output_string:
-        if output_string.startswith("not "):
-            role_names = output_string.replace(" ", "")
+    if "not " in discord_string:
+        if discord_string.startswith("not "):
+            role_names = discord_string.replace(" ", "")
             role_names = role_names.split("not")
             only_nots_in_str = True
             not_role_names = [
@@ -58,7 +59,7 @@ async def count_members(ctx, *, output_string: str):
             ]
         else:
             # two types of operations
-            role_names = output_string.split(" not ")
+            role_names = discord_string.split(" not ")
             only_nots_in_str = False
             not_role_names = [role for role in role_names[1:] if " not " not in role]
         not_roles = []
@@ -72,15 +73,15 @@ async def count_members(ctx, *, output_string: str):
                 )
                 return
         not_roles = [role for role in not_roles if role is not None]
-        output_string = role_names[0]
+        discord_string = role_names[0]
     else:
         not_roles = []
 
     if only_nots_in_str is False:
         role_names = (
-            output_string.split(" and ")
-            if " and " in output_string
-            else output_string.split(" or ")
+            discord_string.split(" and ")
+            if " and " in discord_string
+            else discord_string.split(" or ")
         )
         roles = []
         for role_name in role_names:
@@ -96,20 +97,21 @@ async def count_members(ctx, *, output_string: str):
             return
 
     members = set()
-    if " and " in output_string:
+    if " and " in discord_string:
         role_names = " and ".join(role.name for role in roles)
         for role in roles:
             if not members:  # start if members is empty
                 members.update(role.members)
             else:
                 members &= set(role.members)
-    elif " or " in output_string:
+    elif " or " in discord_string:
         role_names = " or ".join(role.name for role in roles)
         for role in roles:
-            if not members:  # start if members is empty
-                members.update(role.members)
-            else:
-                members &= set(role.members)
+            members.update(role.members)
+    elif only_nots_in_str is False:  # only one positive role
+        role = roles[0]
+        members.update(role.members)
+        role_names = role.name
     else:
         role_names = role_names[0]
         members = set(ctx.guild.members)
@@ -136,18 +138,18 @@ async def count_members(ctx, *, output_string: str):
 
 
 @bot.command()
-async def list_members(ctx, *, output_string: str):
-    """Reads the message from the chat and returns the list of the members
+async def list_members(ctx, *, discord_string: str):
+    Reads the message from the chat and returns the list of the members
     that meet the conditions.
 
     Reads the message if the message starts with the "command_prefix"
     (that was set in when initializing commands.Bot object) and the name
     in the title of the method. Returns str in "ctx.send()".
-    """
+
     only_nots_in_str = False
-    if "not " in output_string:
-        if output_string.startswith("not "):
-            role_names = output_string.replace(" ", "")
+    if "not " in discord_string:
+        if discord_string.startswith("not "):
+            role_names = discord_string.replace(" ", "")
             role_names = role_names.split("not")
             only_nots_in_str = True
             not_role_names = [
@@ -157,7 +159,7 @@ async def list_members(ctx, *, output_string: str):
             ]
         else:
             # two types of operations
-            role_names = output_string.split(" not ")
+            role_names = discord_string.split(" not ")
             only_nots_in_str = False
             not_role_names = [role for role in role_names[1:] if " not " not in role]
         not_roles = []
@@ -171,15 +173,15 @@ async def list_members(ctx, *, output_string: str):
                 )
                 return
         not_roles = [role for role in not_roles if role is not None]
-        output_string = role_names[0]
+        discord_string = role_names[0]
     else:
         not_roles = []
 
     if only_nots_in_str is False:
         role_names = (
-            output_string.split(" and ")
-            if " and " in output_string
-            else output_string.split(" or ")
+            discord_string.split(" and ")
+            if " and " in discord_string
+            else discord_string.split(" or ")
         )
         roles = []
         for role_name in role_names:
@@ -195,20 +197,21 @@ async def list_members(ctx, *, output_string: str):
             return
 
     members = set()
-    if " and " in output_string:
+    if " and " in discord_string:
         role_names = " and ".join(role.name for role in roles)
         for role in roles:
             if not members:  # start if members is empty
                 members.update(role.members)
             else:
                 members &= set(role.members)
-    elif " or " in output_string:
+    elif " or " in discord_string:
         role_names = " or ".join(role.name for role in roles)
         for role in roles:
-            if not members:  # start if members is empty
-                members.update(role.members)
-            else:
-                members &= set(role.members)
+            members.update(role.members)
+    elif only_nots_in_str is False:  # only one positive role
+        role = roles[0]
+        members.update(role.members)
+        role_names = role.name
     else:
         role_names = role_names[0]
         members = set(ctx.guild.members)
@@ -233,43 +236,42 @@ async def list_members(ctx, *, output_string: str):
         await ctx.send(
             f"The members with the roles `{role_names}` are: {member_names}."
         )
+"""
+
+"""
+def converting_new(input_new):
+    converted_input = f"{input_new} + new segment"
+    return converted_input
 
 
-def converting_string(input_string):
-    """Docstring placeholder"""
-    output_string = ""
-    start_index = 0
-    end_index = 0
-    while start_index < len(input_string):
-        start_index = input_string.find("{", end_index)
-        if start_index == -1:
-            output_string += input_string[end_index:]
-            break
-        output_string += input_string[end_index:start_index]
-        end_index = input_string.find("}", start_index)
-        if end_index == -1:
-            output_string += input_string[start_index:]
-            break
-        function_string = input_string[start_index + 1 : end_index]  # noqa: E203
-        if function_string.startswith("list_members "):
-            second_string = function_string[13:]
-            output_string += second_string
-        elif function_string.startswith("count_members "):
-            second_string = function_string[14:]
-            output_string += second_string
-        else:
-            output_string += "{" + function_string + "}"
-        end_index += 1
-    return output_string
+def adding_owner(ctx, converted_input):
+    owner = ctx.guild.owner.mention
+    final_message = f"{converted_input} + {owner}"
+    return final_message
 
 
 @bot.command()
-async def searching_for_roles(ctx, output_string):
+async def show_final_message_in_embed(ctx):
+    input_new = "12345"
+    converted_input = converting_new(input_new)
+    final_message = adding_owner(ctx, converted_input)
+
+    embed_new = discord.Embed(
+        title="Info",
+        description="Info",
+        color=discord.Colour.blue(),
+    )
+    embed_new.add_field(name="Final message", value=f"{final_message}", inline=True)
+    await ctx.send(embed=embed_new)
+"""
+
+
+def counting_members(ctx, second_string):
     """Docstring placeholder"""
     only_nots_in_str = False
-    if "not " in output_string:
-        if output_string.startswith("not "):
-            role_names = output_string.replace(" ", "")
+    if "not " in second_string:
+        if second_string.startswith("not "):
+            role_names = second_string.replace(" ", "")
             role_names = role_names.split("not")
             only_nots_in_str = True
             not_role_names = [
@@ -279,7 +281,7 @@ async def searching_for_roles(ctx, output_string):
             ]
         else:
             # two types of operations
-            role_names = output_string.split(" not ")
+            role_names = second_string.split(" not ")
             only_nots_in_str = False
             not_role_names = [role for role in role_names[1:] if " not " not in role]
         not_roles = []
@@ -293,15 +295,15 @@ async def searching_for_roles(ctx, output_string):
                 )
                 return final_conversion
         not_roles = [role for role in not_roles if role is not None]
-        output_string = role_names[0]
+        second_string = role_names[0]
     else:
         not_roles = []
 
     if only_nots_in_str is False:
         role_names = (
-            output_string.split(" and ")
-            if " and " in output_string
-            else output_string.split(" or ")
+            second_string.split(" and ")
+            if " and " in second_string
+            else second_string.split(" or ")
         )
         roles = []
         for role_name in role_names:
@@ -317,20 +319,101 @@ async def searching_for_roles(ctx, output_string):
             return final_conversion
 
     members = set()
-    if " and " in output_string:
+    if " and " in second_string:
         role_names = " and ".join(role.name for role in roles)
         for role in roles:
             if not members:  # start if members is empty
                 members.update(role.members)
             else:
                 members &= set(role.members)
-    elif " or " in output_string:
+    elif " or " in second_string:
         role_names = " or ".join(role.name for role in roles)
+        for role in roles:
+            members.update(role.members)
+    elif only_nots_in_str is False:  # only one positive role
+        role = roles[0]
+        members.update(role.members)
+        role_names = role.name
+    else:
+        role_names = role_names[0]
+        members = set(ctx.guild.members)
+
+    for not_role in not_roles:
+        members -= set(not_role.members)
+
+    num_members = len(members)
+    final_conversion = str(num_members)
+    return final_conversion
+
+
+def listing_members(ctx, second_string):
+    """Docstring placeholder"""
+    only_nots_in_str = False
+    if "not " in second_string:
+        if second_string.startswith("not "):
+            role_names = second_string.replace(" ", "")
+            role_names = role_names.split("not")
+            only_nots_in_str = True
+            not_role_names = [
+                role
+                for role in role_names[1:]
+                if " not " not in role or "not " not in role
+            ]
+        else:
+            # two types of operations
+            role_names = second_string.split(" not ")
+            only_nots_in_str = False
+            not_role_names = [role for role in role_names[1:] if " not " not in role]
+        not_roles = []
+        for not_role_name in not_role_names:
+            not_role = discord.utils.get(ctx.guild.roles, name=not_role_name)
+            if not_role is not None:
+                not_roles.append(not_role)
+            else:
+                final_conversion = (
+                    f"Could not find `{not_role_name}` role. Check spelling."
+                )
+                return final_conversion
+        not_roles = [role for role in not_roles if role is not None]
+        second_string = role_names[0]
+    else:
+        not_roles = []
+
+    if only_nots_in_str is False:
+        role_names = (
+            second_string.split(" and ")
+            if " and " in second_string
+            else second_string.split(" or ")
+        )
+        roles = []
+        for role_name in role_names:
+            role = discord.utils.get(ctx.guild.roles, name=role_name)
+            if role is not None:
+                roles.append(role)
+            else:
+                final_conversion = f"Could not find `{role_name}` role. Check spelling."
+                return final_conversion
+        roles = [role for role in roles if role is not None]
+        if not roles:
+            final_conversion = "Could not find one or more roles. Check spelling."
+            return final_conversion
+
+    members = set()
+    if " and " in second_string:
+        role_names = " and ".join(role.name for role in roles)
         for role in roles:
             if not members:  # start if members is empty
                 members.update(role.members)
             else:
                 members &= set(role.members)
+    elif " or " in second_string:
+        role_names = " or ".join(role.name for role in roles)
+        for role in roles:
+            members.update(role.members)
+    elif only_nots_in_str is False:  # only one positive role
+        role = roles[0]
+        members.update(role.members)
+        role_names = role.name
     else:
         role_names = role_names[0]
         members = set(ctx.guild.members)
@@ -345,8 +428,54 @@ async def searching_for_roles(ctx, output_string):
     return final_conversion
 
 
+def converting_string(ctx, input_string):
+    """Docstring placeholder"""
+    output_string = ""
+    start_index = 0
+    end_index = 0
+    while start_index < len(input_string):
+        start_index = input_string.find("{", end_index)
+        if start_index == -1:
+            output_string += input_string[end_index:]
+            break
+        output_string += input_string[end_index:start_index]
+        end_index = input_string.find("}", start_index)
+        if end_index == -1:
+            output_string += input_string[start_index:]
+            break
+        print(f"output_String1: {output_string}")
+        function_string = input_string[start_index + 1 : end_index]  # noqa: E203
+        if function_string.startswith("list_members "):
+            second_string = function_string[13:]
+            final_conversion = listing_members(ctx, second_string)
+            output_string += final_conversion
+        elif function_string.startswith("count_members "):
+            second_string = function_string[14:]
+            final_conversion = counting_members(ctx, second_string)
+            output_string += final_conversion
+        else:
+            output_string += "{" + function_string + "}"
+        end_index += 1
+    return output_string
+
+
 @bot.command()
-async def server(ctx, final_conversion):
+async def embed(ctx):
+    """Docstring placeholder"""
+    input_string = """
+    Num of members with roles test and 2 but not 1:
+    {count_members test and 2 not 1}
+    These people are:
+    {list_members test and 2 not 1}"""
+    output_string = converting_string(ctx, input_string)
+
+    simple_embed = discord.Embed()
+    simple_embed.add_field(name="", value=f"{output_string}", inline=True)
+    await ctx.send(embed=simple_embed)
+
+
+@bot.command()
+async def server(ctx):
     """Reads the message from the chat and returns
     embeded message with server stats.
 
@@ -366,9 +495,6 @@ async def server(ctx, final_conversion):
     - Footer message
     - Message anuthor and his icon.
     """
-    input_string = "hello {list_members admin and prezes}"
-    output_string = converting_string(input_string)
-    final_conversion = await searching_for_roles(ctx, output_string)
 
     embed_1 = discord.Embed(
         title=f"{ctx.guild.name} Info",
@@ -401,7 +527,7 @@ async def server(ctx, final_conversion):
     embed_1.set_thumbnail(url=ctx.guild.icon)
     embed_1.set_footer(text="⭐PLACEHOLDER⭐")
     embed_1.set_author(name=f"{ctx.author.name}", icon_url=ctx.message.author.avatar)
-    embed_1.add_field(name="Description", value=final_conversion, inline=False)
+    embed_1.add_field(name="Description", value="123", inline=False)
     await ctx.send(embed=embed_1)
 
 

--- a/bot.py
+++ b/bot.py
@@ -8,7 +8,6 @@ import discord
 from discord.ext import commands
 from dotenv import load_dotenv
 
-
 load_dotenv()  # loads your local .env file with discord token
 
 intents = discord.Intents.default()
@@ -38,7 +37,7 @@ async def hello(ctx):
 
 
 @bot.command()
-async def count_members(ctx, *, role_names_str: str):
+async def count_members(ctx, *, output_string: str):
     """Reads the message from the chat and returns the number of members
     that meet the conditions.
 
@@ -47,9 +46,9 @@ async def count_members(ctx, *, role_names_str: str):
     in the title of the method. Returns str in "ctx.send()".
     """
     only_nots_in_str = False
-    if "not " in role_names_str:
-        if role_names_str.startswith("not "):
-            role_names = role_names_str.replace(" ", "")
+    if "not " in output_string:
+        if output_string.startswith("not "):
+            role_names = output_string.replace(" ", "")
             role_names = role_names.split("not")
             only_nots_in_str = True
             not_role_names = [
@@ -59,7 +58,7 @@ async def count_members(ctx, *, role_names_str: str):
             ]
         else:
             # two types of operations
-            role_names = role_names_str.split(" not ")
+            role_names = output_string.split(" not ")
             only_nots_in_str = False
             not_role_names = [role for role in role_names[1:] if " not " not in role]
         not_roles = []
@@ -73,15 +72,15 @@ async def count_members(ctx, *, role_names_str: str):
                 )
                 return
         not_roles = [role for role in not_roles if role is not None]
-        role_names_str = role_names[0]
+        output_string = role_names[0]
     else:
         not_roles = []
 
     if only_nots_in_str is False:
         role_names = (
-            role_names_str.split(" and ")
-            if " and " in role_names_str
-            else role_names_str.split(" or ")
+            output_string.split(" and ")
+            if " and " in output_string
+            else output_string.split(" or ")
         )
         roles = []
         for role_name in role_names:
@@ -97,14 +96,14 @@ async def count_members(ctx, *, role_names_str: str):
             return
 
     members = set()
-    if " and " in role_names_str:
+    if " and " in output_string:
         role_names = " and ".join(role.name for role in roles)
         for role in roles:
             if not members:  # start if members is empty
                 members.update(role.members)
             else:
                 members &= set(role.members)
-    elif " or " in role_names_str:
+    elif " or " in output_string:
         role_names = " or ".join(role.name for role in roles)
         for role in roles:
             if not members:  # start if members is empty
@@ -137,7 +136,7 @@ async def count_members(ctx, *, role_names_str: str):
 
 
 @bot.command()
-async def list_members(ctx, *, role_names_str: str):
+async def list_members(ctx, *, output_string: str):
     """Reads the message from the chat and returns the list of the members
     that meet the conditions.
 
@@ -146,9 +145,9 @@ async def list_members(ctx, *, role_names_str: str):
     in the title of the method. Returns str in "ctx.send()".
     """
     only_nots_in_str = False
-    if "not " in role_names_str:
-        if role_names_str.startswith("not "):
-            role_names = role_names_str.replace(" ", "")
+    if "not " in output_string:
+        if output_string.startswith("not "):
+            role_names = output_string.replace(" ", "")
             role_names = role_names.split("not")
             only_nots_in_str = True
             not_role_names = [
@@ -158,7 +157,7 @@ async def list_members(ctx, *, role_names_str: str):
             ]
         else:
             # two types of operations
-            role_names = role_names_str.split(" not ")
+            role_names = output_string.split(" not ")
             only_nots_in_str = False
             not_role_names = [role for role in role_names[1:] if " not " not in role]
         not_roles = []
@@ -172,15 +171,15 @@ async def list_members(ctx, *, role_names_str: str):
                 )
                 return
         not_roles = [role for role in not_roles if role is not None]
-        role_names_str = role_names[0]
+        output_string = role_names[0]
     else:
         not_roles = []
 
     if only_nots_in_str is False:
         role_names = (
-            role_names_str.split(" and ")
-            if " and " in role_names_str
-            else role_names_str.split(" or ")
+            output_string.split(" and ")
+            if " and " in output_string
+            else output_string.split(" or ")
         )
         roles = []
         for role_name in role_names:
@@ -196,14 +195,14 @@ async def list_members(ctx, *, role_names_str: str):
             return
 
     members = set()
-    if " and " in role_names_str:
+    if " and " in output_string:
         role_names = " and ".join(role.name for role in roles)
         for role in roles:
             if not members:  # start if members is empty
                 members.update(role.members)
             else:
                 members &= set(role.members)
-    elif " or " in role_names_str:
+    elif " or " in output_string:
         role_names = " or ".join(role.name for role in roles)
         for role in roles:
             if not members:  # start if members is empty
@@ -236,8 +235,118 @@ async def list_members(ctx, *, role_names_str: str):
         )
 
 
+def converting_string(input_string):
+    """Docstring placeholder"""
+    output_string = ""
+    start_index = 0
+    end_index = 0
+    while start_index < len(input_string):
+        start_index = input_string.find("{", end_index)
+        if start_index == -1:
+            output_string += input_string[end_index:]
+            break
+        output_string += input_string[end_index:start_index]
+        end_index = input_string.find("}", start_index)
+        if end_index == -1:
+            output_string += input_string[start_index:]
+            break
+        function_string = input_string[start_index + 1 : end_index]  # noqa: E203
+        if function_string.startswith("list_members "):
+            second_string = function_string[13:]
+            output_string += second_string
+        elif function_string.startswith("count_members "):
+            second_string = function_string[14:]
+            output_string += second_string
+        else:
+            output_string += "{" + function_string + "}"
+        end_index += 1
+    return output_string
+
+
 @bot.command()
-async def server(ctx):
+async def searching_for_roles(ctx, output_string):
+    """Docstring placeholder"""
+    only_nots_in_str = False
+    if "not " in output_string:
+        if output_string.startswith("not "):
+            role_names = output_string.replace(" ", "")
+            role_names = role_names.split("not")
+            only_nots_in_str = True
+            not_role_names = [
+                role
+                for role in role_names[1:]
+                if " not " not in role or "not " not in role
+            ]
+        else:
+            # two types of operations
+            role_names = output_string.split(" not ")
+            only_nots_in_str = False
+            not_role_names = [role for role in role_names[1:] if " not " not in role]
+        not_roles = []
+        for not_role_name in not_role_names:
+            not_role = discord.utils.get(ctx.guild.roles, name=not_role_name)
+            if not_role is not None:
+                not_roles.append(not_role)
+            else:
+                final_conversion = (
+                    f"Could not find `{not_role_name}` role. Check spelling."
+                )
+                return final_conversion
+        not_roles = [role for role in not_roles if role is not None]
+        output_string = role_names[0]
+    else:
+        not_roles = []
+
+    if only_nots_in_str is False:
+        role_names = (
+            output_string.split(" and ")
+            if " and " in output_string
+            else output_string.split(" or ")
+        )
+        roles = []
+        for role_name in role_names:
+            role = discord.utils.get(ctx.guild.roles, name=role_name)
+            if role is not None:
+                roles.append(role)
+            else:
+                final_conversion = f"Could not find `{role_name}` role. Check spelling."
+                return final_conversion
+        roles = [role for role in roles if role is not None]
+        if not roles:
+            final_conversion = "Could not find one or more roles. Check spelling."
+            return final_conversion
+
+    members = set()
+    if " and " in output_string:
+        role_names = " and ".join(role.name for role in roles)
+        for role in roles:
+            if not members:  # start if members is empty
+                members.update(role.members)
+            else:
+                members &= set(role.members)
+    elif " or " in output_string:
+        role_names = " or ".join(role.name for role in roles)
+        for role in roles:
+            if not members:  # start if members is empty
+                members.update(role.members)
+            else:
+                members &= set(role.members)
+    else:
+        role_names = role_names[0]
+        members = set(ctx.guild.members)
+
+    for not_role in not_roles:
+        members -= set(not_role.members)
+
+    members = list(members)
+    member_names = ", ".join(member.mention for member in members)
+    not_role_names = ", ".join(not_role.name for not_role in not_roles)
+    final_conversion = member_names
+    return final_conversion
+
+
+@bot.command()
+async def server(ctx, final_conversion):
     """Reads the message from the chat and returns
     embeded message with server stats.
 
@@ -257,6 +366,9 @@ async def server(ctx):
     - Footer message
     - Message anuthor and his icon.
     """
+    input_string = "hello {list_members admin and prezes}"
+    output_string = converting_string(input_string)
+    final_conversion = await searching_for_roles(ctx, output_string)
 
     embed_1 = discord.Embed(
         title=f"{ctx.guild.name} Info",
@@ -289,7 +401,7 @@ async def server(ctx):
     embed_1.set_thumbnail(url=ctx.guild.icon)
     embed_1.set_footer(text="⭐PLACEHOLDER⭐")
     embed_1.set_author(name=f"{ctx.author.name}", icon_url=ctx.message.author.avatar)
-    embed_1.add_field(name="Description", value="123", inline=False)
+    embed_1.add_field(name="Description", value=final_conversion, inline=False)
     await ctx.send(embed=embed_1)
 
 

--- a/bot.py
+++ b/bot.py
@@ -116,48 +116,72 @@ async def list_members(ctx, *, role_names_str: str):
     in the title of the method. Returns str in "ctx.send()".
     """
     not_roles = []
-    if " not " in role_names_str:
-        role_names = role_names_str.split(" not ")
-        role_names = [role.strip() for role in role_names if role]
-        not_role_names = [role for role in role_names[1:] if " not " not in role]
+    role_names = []
+    only_nots_in_str = False
+    print(role_names_str)
+    if "not " in role_names_str:
+        if role_names_str.startswith("not "):
+            role_names = role_names_str.replace(" ", "")
+            role_names = role_names.split("not")
+            print(f"role_names: {role_names}")
+            
+            print("1")
+            only_nots_in_str = True
+            not_role_names = [role for role in role_names[1:] if " not " not in role or "not " not in role]
+            print(not_role_names)
+        else:
+            role_names = role_names_str.split(" not ")
+            print("2")
+            only_nots_in_str = False
+            not_role_names = [role for role in role_names[1:] if " not " not in role]
+            print(not_role_names)
         not_roles = [
             discord.utils.get(ctx.guild.roles, name=not_role_name)
             for not_role_name in not_role_names
         ]
         not_roles = [role for role in not_roles if role is not None]
         role_names_str = role_names[0]
+        print(f"role_names_str: {role_names_str}")
     else:
         not_roles = []
-
-    role_names = (
-        role_names_str.split(" and ")
-        if " and " in role_names_str
-        else role_names_str.split(" or ")
-    )
-    operator = "and" if " and " in role_names_str else "or"
-
-    roles = [
-        discord.utils.get(ctx.guild.roles, name=role_name) for role_name in role_names
-    ]
-    roles = [role for role in roles if role is not None]
-    if not roles:
-        await ctx.send(
-            f"Could not find any of the roles with names `{role_names_str}`."
+    
+    if only_nots_in_str is False:
+        role_names = (
+            role_names_str.split(" and ")
+            if " and " in role_names_str
+            else role_names_str.split(" or ")
         )
-        return
+
+        roles = [
+            discord.utils.get(ctx.guild.roles, name=role_name) for role_name in role_names
+        ]
+        roles = [role for role in roles if role is not None]
+        if not roles:
+            await ctx.send(
+                f"Could not find any of the roles with names `{role_names_str}`."
+            )
+            return
 
     members = set()
-    if operator == "and":
+    if " and " in role_names_str:
+        operator = "and"
         role_names = " and ".join(role.name for role in roles)
         for role in roles:
-            if not members:
+            if not members:  # start if members is empty
+                members.update(role.members)
+            else:
+                members &= set(role.members)
+    elif " or " in role_names_str:
+        operator = "or"
+        role_names = " or ".join(role.name for role in roles)
+        for role in roles:
+            if not members:  # start if members is empty
                 members.update(role.members)
             else:
                 members &= set(role.members)
     else:
-        role_names = " or ".join(role.name for role in roles)
-        for role in roles:
-            members.update(role.members)
+        operator = None
+        members = set(ctx.guild.members)
 
     for not_role in not_roles:
         members -= set(not_role.members)
@@ -166,10 +190,15 @@ async def list_members(ctx, *, role_names_str: str):
     member_names = ", ".join(member.mention for member in members)
     not_role_names = ", ".join(not_role.name for not_role in not_roles)
     if not_roles:
-        await ctx.send(
-            f"The members with the roles `{role_names}`"
-            f" but not the roles `{not_role_names}` are: {member_names}."
-        )
+        if only_nots_in_str is True:
+            await ctx.send(
+                f"The members without roles {not_role_names} are: {member_names}."
+            )
+        else:
+            await ctx.send(
+                f"The members with the roles `{role_names}`"
+                f" but not the roles `{not_role_names}` are: {member_names}."
+            )
     else:
         await ctx.send(
             f"The members with the roles `{role_names}` are: {member_names}."


### PR DESCRIPTION
Nowe dwie funkcje na czacie Discorda:
- count_members
- list_members

Do obu można podać dowolną ilość argumentów przedzielonych operatorami and, or, not. Operatory można używać w grupach: and i not, or i not, lub dowolne same. W tym momencie nie można łączyć operatorów or i and, występuje też warunek, że najpierw muszą się znaleźć wszystkie operatory and lub wszystkie operatory or, później wszystkie operatory not.

Przykłady:
![image](https://user-images.githubusercontent.com/117805804/218268081-ecd6edc7-a1f1-4d87-aeb2-e8277f608023.png)

![image](https://user-images.githubusercontent.com/117805804/218268190-8598c87c-446b-43e5-ae4d-e5ef55d1b429.png)

![image](https://user-images.githubusercontent.com/117805804/218268004-27075b4b-8f29-4fbb-8fbf-69869c024eb9.png)
